### PR TITLE
Support Ruby 1.9 syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 rvm:
-  - 2.3.0
+  - 1.9.3
+  - 2.3.1
 before_install: gem install bundler -v 1.11.2

--- a/alt
+++ b/alt
@@ -23,7 +23,7 @@ require 'benchmark'
 class Alt
   VERSION='0.0.1'
 
-  def initialize(argv: ARGV)
+  def initialize(argv = ARGV)
     @argv = argv
     @path = nil
     @options = { version: false, stdin: false, debug: false }


### PR DESCRIPTION
Hi, 

It may sound odd, but I'm still using Ruby 1.9 for some projects 😸 
Would you like to support it? 

Ruby community stopped supporting it more than [1 year ago](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/), 
but as far as I can see it's quite easy to make `alt` work with this version of Ruby as well.